### PR TITLE
Printing error messages rather than the error object

### DIFF
--- a/src/ChatComponent.jsx
+++ b/src/ChatComponent.jsx
@@ -342,7 +342,10 @@ const ChatComponent = ({ user, onLogout, onConfigEditorClick }) => {
 
       } catch (err) {
         console.error('Error invoking agent:', err);
-        const errorMessage = { text: `An error occurred while processing your request. Error: ${JSON.stringify(err, null, 2)}`, sender: 'agent' };
+
+        let errReason = "**"+String(err).toString()+"**";
+
+        const errorMessage = { text: `An error occurred while processing your request:\n${errReason}`, sender: 'agent' };
         setMessages(prevMessages => [...prevMessages, errorMessage]);
         storeMessages(sessionId, [userMessage, errorMessage]);
       } finally {


### PR DESCRIPTION
Printing error messages rather than the error object, error object will remain printed in the console


*Description of changes:*
In the past, the error JSON structure was printed in the history chat. Now, the error message is printed in the chat, and the error object is logged in the browser console.
